### PR TITLE
chore: enable Dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    ignore:
+      - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "deps"
-    ignore:
-      - dependency-name: "*"


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically keep npm dependencies up-to-date and address security vulnerabilities, including the recently reported CVE-2026-59874 (high severity) affecting tar.